### PR TITLE
Resolved setting veil for line_edit bug

### DIFF
--- a/include/termox/widget/widgets/line_edit.hpp
+++ b/include/termox/widget/widgets/line_edit.hpp
@@ -56,21 +56,6 @@ class Line_edit : public Textbox {
     /** This is disabled by default. */
     void clear_on_enter(bool enable = true) { clear_on_enter_ = enable; }
 
-    /// Set whether the Line_edit has veilded output, doesn't alter the content.
-    /** Disabled by default, uses '*' to veil by default. */
-    void veil_text(bool enable = true)
-    {
-        is_veiled_ = enable;
-        this->update();
-    }
-
-    /// Set Glyph used to obscure the display.
-    void set_veil(Glyph veil)
-    {
-        veil_ = veil;
-        this->update();
-    }
-
     /// Set whether the Line_edit has an underline.
     /** Disabled by default. The entire length of the box is underlined if
      *  enabled. */
@@ -78,6 +63,9 @@ class Line_edit : public Textbox {
 
     /// Set color of the initial text, before focus has been given to this.
     void set_ghost_color(Color c);
+
+    using Text_display::veil_text;
+    using Text_display::set_veil;
 
    protected:
     auto key_press_event(Key k) -> bool override;
@@ -91,18 +79,9 @@ class Line_edit : public Textbox {
         return Textbox::focus_in_event();
     }
 
-    auto paint_event() -> bool override
-    {
-        if (is_veiled_)
-            this->set_contents(Glyph_string{veil_, this->contents().size()});
-        return Textbox::paint_event();
-    }
-
    private:
     bool clear_on_enter_   = false;
     bool on_initial_       = true;
-    bool is_veiled_        = false;
-    Glyph veil_            = L'*';
     Validator_t validator_ = [](char) { return true; };
 };
 

--- a/include/termox/widget/widgets/text_display.hpp
+++ b/include/termox/widget/widgets/text_display.hpp
@@ -235,6 +235,21 @@ class Text_display : public Widget {
      *  wrap is enabled, and the contents.*/
     void update_display(std::size_t from_line = 0);
 
+    /// Set whether the Line_edit has veilded output, doesn't alter the content.
+    /** Disabled by default, uses '*' to veil by default. */
+    void veil_text(bool enable = true)
+    {
+        is_veiled_ = enable;
+        this->update();
+    }
+
+    /// Set Glyph used to obscure the display.
+    void set_veil(Glyph veil)
+    {
+        veil_ = veil;
+        this->update();
+    }
+
    private:
     /// Provides a start index into contents and total length for a text line.
     struct Line_info {
@@ -248,6 +263,8 @@ class Text_display : public Widget {
     Align alignment_        = Align::Left;
     Glyph_string contents_;
     std::vector<Line_info> display_state_ = {Line_info{0, 0}};
+    bool is_veiled_        = false;
+    Glyph veil_            = L'*';
 };
 
 /// Helper function to create an instance.

--- a/src/widget/text_display.cpp
+++ b/src/widget/text_display.cpp
@@ -145,8 +145,6 @@ auto Text_display::paint_event() -> bool
     auto p      = Painter{*this};
     auto line_n = 0uL;
     auto paint  = [&p, &line_n, this](Line_info const& line) {
-        auto const sub_begin = std::begin(this->contents_) + line.start_index;
-        auto const sub_end   = sub_begin + line.length;
         auto start           = 0uL;
         switch (alignment_) {
             case Align::Top:
@@ -157,6 +155,14 @@ auto Text_display::paint_event() -> bool
             case Align::Bottom:
             case Align::Right: start = this->width() - line.length; break;
         }
+
+        if (is_veiled_) {
+            p.put(Glyph_string{veil_, line.length}, start, line_n++);
+            return;
+        }
+
+        auto const sub_begin = std::begin(this->contents_) + line.start_index;
+        auto const sub_end   = sub_begin + line.length;
         p.put(Glyph_string(sub_begin, sub_end), start, line_n++);
     };
     auto const begin = std::begin(display_state_) + this->top_line();


### PR DESCRIPTION
If I set a veil for line_edit, application would crash. Because it
creates an infinite recursive call loop from calling `set_content()`
in `paint_event()`. I could not find a solution to this bug in the
line_edit itself, so I moved veil settings to text_display which
renders text changes and only show veil glyph is veil is enabled.
Now `content()` returns real content too, not something changed by
veil character.

This is a solution for #46 .