### PR TITLE
C++20 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # TermOx 🐂
 
-**TermOx** is a Terminal User Interface(TUI) Framework written in  C++17. Built
+**TermOx** is a Terminal User Interface(TUI) Framework written in C++17 (but with support for C++20). Built
 on top of [Escape](https://github.com/a-n-t-h-o-n-y/Escape), it defines a set of
 Widgets, Layouts, and Events that make it quick to craft unique user interfaces
 in the terminal.

--- a/src/terminal/detail/canvas.cpp
+++ b/src/terminal/detail/canvas.cpp
@@ -7,6 +7,7 @@
 #include <ostream>
 #include <vector>
 
+#include <termox/common/u32_to_mb.hpp>
 #include <termox/painter/brush.hpp>
 #include <termox/painter/color.hpp>
 #include <termox/painter/glyph.hpp>
@@ -152,7 +153,7 @@ auto print(Canvas::Diff const& diff, std::ostream& os) -> std::ostream&
     // using Diff = std::vector<std::pair<ox::Point, ox::Glyph>>;
     for (auto const& [point, glyph] : diff) {
         os << "Point: {" << point.x << ", " << point.y << "}\n";
-        os << "Glyph: symbol: " << glyph.symbol << '\n';
+        os << "Glyph: symbol: " << u32_to_mb(glyph.symbol) << '\n';
         os << "----------------------\n";
     }
     return os;


### PR DESCRIPTION
Since C++20 deletes stream operators for wide characters, use the preexisting `u32_to_mb` function to convert it. The codebase now compiles with C++20.

Additionally, update the README to indicate the C++20 support.